### PR TITLE
Add heroku-16 Dockerfile

### DIFF
--- a/heroku-16.dockerfile
+++ b/heroku-16.dockerfile
@@ -1,0 +1,19 @@
+FROM heroku/heroku:16
+MAINTAINER Akash Manohar
+
+RUN apt-get update
+
+RUN apt-get install -y curl wget ca-certificates
+RUN apt-get install -y gcc g++
+RUN apt-get install -y make automake autoconf
+RUN apt-get install -y libwxgtk3.0-dev libgl1-mesa-dev libglu1-mesa-dev libpng3
+RUN apt-get install -y libreadline-dev libncurses-dev libssl-dev libssh-dev
+RUN apt-get install -y libxslt-dev libffi-dev libtool unixodbc-dev
+RUN apt-get install -y fop xsltproc
+
+RUN mkdir -p /home/build/out
+WORKDIR /home/build
+
+COPY build-otp.sh /home/build/build.sh
+RUN chmod +x /home/build/build.sh
+CMD ./build.sh


### PR DESCRIPTION
 Build Erlang OTP using the [heroku-16 stack](https://devcenter.heroku.com/articles/heroku-16-stack)

e.g. Build by using the following command:
`HEROKU_STACK=heroku-16 ./build.sh 20.0`
